### PR TITLE
Fix the deleting functionality for interns and companies

### DIFF
--- a/BackEnd/paltechlinker/src/main/java/com/gsg/paltechlinker/controllers/CompanyController.java
+++ b/BackEnd/paltechlinker/src/main/java/com/gsg/paltechlinker/controllers/CompanyController.java
@@ -5,6 +5,8 @@ import com.gsg.paltechlinker.domain.dto.CompanyDto;
 import com.gsg.paltechlinker.domain.entities.CompanyEntity;
 import com.gsg.paltechlinker.mappers.Mapper;
 import com.gsg.paltechlinker.services.CompanyService;
+import com.gsg.paltechlinker.services.InternshipService;
+
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -16,11 +18,13 @@ import org.springframework.http.ResponseEntity;
 public class CompanyController {
 
     private CompanyService companyService;
+    private InternshipService internshipService;
     private Mapper<CompanyEntity, CompanyDto> mapper;
 
 
-    public CompanyController(CompanyService companyService, Mapper<CompanyEntity, CompanyDto> mapper) {
+    public CompanyController(CompanyService companyService, InternshipService internshipService, Mapper<CompanyEntity, CompanyDto> mapper) {
         this.companyService = companyService;
+        this.internshipService = internshipService;
         this.mapper = mapper;
     }
     
@@ -71,6 +75,7 @@ public class CompanyController {
 
     @DeleteMapping("/delete/{id}")
     public ResponseEntity<Void> deleteCompany(@PathVariable Long id) {
+        internshipService.deleteByCompanyId(id);
         companyService.delete(id);
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }

--- a/BackEnd/paltechlinker/src/main/java/com/gsg/paltechlinker/domain/entities/InternshipEntity.java
+++ b/BackEnd/paltechlinker/src/main/java/com/gsg/paltechlinker/domain/entities/InternshipEntity.java
@@ -46,7 +46,7 @@ public class InternshipEntity {
     @Enumerated(EnumType.STRING)
     private InternshipType type;
 
-    @ManyToOne(cascade = CascadeType.ALL)
+    @ManyToOne(cascade = {CascadeType.PERSIST, CascadeType.MERGE})
     @JoinColumn(name = "company_id")
     private CompanyEntity company;
 }

--- a/BackEnd/paltechlinker/src/main/java/com/gsg/paltechlinker/repositories/InternshipRepository.java
+++ b/BackEnd/paltechlinker/src/main/java/com/gsg/paltechlinker/repositories/InternshipRepository.java
@@ -5,11 +5,15 @@ import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.PagingAndSortingRepository;
 import org.springframework.stereotype.Repository;
 import com.gsg.paltechlinker.domain.entities.InternshipEntity;
+import jakarta.transaction.Transactional;
 
 @Repository
 public interface InternshipRepository extends CrudRepository<InternshipEntity, Long>,
                                             PagingAndSortingRepository<InternshipEntity, Long> {    
 
     List<InternshipEntity> findByCompanyId(Long companyId);
+
+    @Transactional
+    void deleteByCompanyId(Long companyId);
 
 }

--- a/BackEnd/paltechlinker/src/main/java/com/gsg/paltechlinker/services/InternshipService.java
+++ b/BackEnd/paltechlinker/src/main/java/com/gsg/paltechlinker/services/InternshipService.java
@@ -7,6 +7,8 @@ import org.springframework.data.domain.Pageable;
 
 import com.gsg.paltechlinker.domain.entities.InternshipEntity;
 
+import jakarta.transaction.Transactional;
+
 public interface InternshipService {
     
     InternshipEntity save(InternshipEntity internshipEntity);
@@ -22,4 +24,7 @@ public interface InternshipService {
     boolean isExists(Long id);
 
     List<InternshipEntity> findByCompanyId(Long companyId);
+
+    @Transactional
+    void deleteByCompanyId(Long companyId);
 }

--- a/BackEnd/paltechlinker/src/main/java/com/gsg/paltechlinker/services/impl/InternshipServiceImpl.java
+++ b/BackEnd/paltechlinker/src/main/java/com/gsg/paltechlinker/services/impl/InternshipServiceImpl.java
@@ -9,6 +9,8 @@ import com.gsg.paltechlinker.domain.entities.InternshipEntity;
 import com.gsg.paltechlinker.repositories.InternshipRepository;
 import com.gsg.paltechlinker.services.InternshipService;
 
+import jakarta.transaction.Transactional;
+
 @Service
 public class InternshipServiceImpl implements InternshipService {
 
@@ -60,6 +62,13 @@ public class InternshipServiceImpl implements InternshipService {
     @Override
     public List<InternshipEntity> findByCompanyId(Long companyId) {
         return internshipRepository.findByCompanyId(companyId);
+    }
+
+
+    @Transactional
+    @Override
+    public void deleteByCompanyId(Long companyId) {
+        internshipRepository.deleteByCompanyId(companyId);
     }
     
 }


### PR DESCRIPTION
- updated cascade type from `CascadeType.All` to `{CascadeType.PERSIST, CascadeType.MERGE}`
- add another method to delete all interns related to a specific company
- modify the delete endpoint in `CompanyController` to delete all related interns when deleting the company